### PR TITLE
Fix for testing error pages

### DIFF
--- a/smoked/test/url.py
+++ b/smoked/test/url.py
@@ -2,8 +2,12 @@
 from __future__ import unicode_literals
 
 from django.utils.six.moves.urllib.request import urlopen
+from django.utils.six.moves.urllib.error import HTTPError
 
 
 def url_available(url=None, expected_code=200):
     """ Check availability (HTTP response code) of single resource """
-    assert urlopen(url).getcode() == expected_code
+    try:
+        assert urlopen(url).getcode() == expected_code
+    except HTTPError as e:
+        assert e.code == expected_code


### PR DESCRIPTION
Cannot test error pages, because urlopen raise http exception
`url_available(url='http://doesnotexist.com', expected_code=404) # raise exception`
